### PR TITLE
feat: allow additional IAM roles for operations

### DIFF
--- a/ecr_access.tf
+++ b/ecr_access.tf
@@ -28,21 +28,26 @@ resource "aws_iam_policy" "ecr_access" {
   tags   = var.tags
 }
 
-resource "aws_iam_role_policy_attachment" "ecr_access_provision" {
-  count      = var.provision_iam_role_arn != "" ? 1 : 0
-  role       = local.roles.provision_iam_role_name
+resource "aws_iam_role_policy_attachment" "ecr_access" {
+  for_each   = local.all_role_names
+  role       = each.value
   policy_arn = aws_iam_policy.ecr_access.arn
 }
 
-resource "aws_iam_role_policy_attachment" "ecr_access_maintenance" {
-  role       = local.roles.maintenance_iam_role_name
-  policy_arn = aws_iam_policy.ecr_access.arn
+# State migration: map old singular resources to new for_each keys
+moved {
+  from = aws_iam_role_policy_attachment.ecr_access_provision[0]
+  to   = aws_iam_role_policy_attachment.ecr_access["provision-0"]
 }
 
-resource "aws_iam_role_policy_attachment" "ecr_access_deprovision" {
-  count      = var.deprovision_iam_role_arn != "" ? 1 : 0
-  role       = local.roles.deprovision_iam_role_name
-  policy_arn = aws_iam_policy.ecr_access.arn
+moved {
+  from = aws_iam_role_policy_attachment.ecr_access_maintenance
+  to   = aws_iam_role_policy_attachment.ecr_access["maintenance-0"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.ecr_access_deprovision[0]
+  to   = aws_iam_role_policy_attachment.ecr_access["deprovision-0"]
 }
 
 resource "aws_iam_role_policy_attachment" "ecr_access_break_glass" {

--- a/eks.tf
+++ b/eks.tf
@@ -8,34 +8,37 @@ locals {
   desired_size   = var.desired_size
 
   // access entries
-  // three roles in play: provision, deprovision, maintenance
-  // provision and deprovision are conditionally created based on whether their ARNs are provided
-  default_access_entries = {
-    "maintenance" = {
-      principal_arn       = var.maintenance_iam_role_arn
-      kubernetes_groups   = concat(["maintenance"], var.maintenance_role_eks_kubernetes_groups)
-      policy_associations = var.maintenance_role_eks_access_entry_policy_associations,
+  // three role types: provision, deprovision, maintenance
+  // each supports multiple ARNs via additional_*_iam_role_arns variables
+  provision_access_entries = {
+    for i, arn in local.all_provision_arns :
+    "provision-${i}" => {
+      principal_arn       = arn
+      kubernetes_groups   = concat(["provision"], var.provision_role_eks_kubernetes_groups)
+      policy_associations = var.provision_role_eks_access_entry_policy_associations
       tags                = local.tags
-    },
+    }
   }
 
-  provision_access_entry = var.provision_iam_role_arn != "" ? {
-    "provision" = {
-      principal_arn       = var.provision_iam_role_arn
-      kubernetes_groups   = concat(["provision"], var.provision_role_eks_kubernetes_groups)
-      policy_associations = var.provision_role_eks_access_entry_policy_associations,
-      tags                = local.tags
-    },
-  } : {}
-
-  deprovision_access_entry = var.deprovision_iam_role_arn != "" ? {
-    "deprovision" = {
-      principal_arn       = var.deprovision_iam_role_arn
+  deprovision_access_entries = {
+    for i, arn in local.all_deprovision_arns :
+    "deprovision-${i}" => {
+      principal_arn       = arn
       kubernetes_groups   = concat(["deprovision"], var.deprovision_role_eks_kubernetes_groups)
-      policy_associations = var.deprovision_role_eks_access_entry_policy_associations,
+      policy_associations = var.deprovision_role_eks_access_entry_policy_associations
       tags                = local.tags
-    },
-  } : {}
+    }
+  }
+
+  maintenance_access_entries = {
+    for i, arn in local.all_maintenance_arns :
+    "maintenance-${i}" => {
+      principal_arn       = arn
+      kubernetes_groups   = concat(["maintenance"], var.maintenance_role_eks_kubernetes_groups)
+      policy_associations = var.maintenance_role_eks_access_entry_policy_associations
+      tags                = local.tags
+    }
+  }
 
   break_glass_access_entry = var.break_glass_iam_role_arn != "" ? {
     "break_glass" = {
@@ -46,7 +49,7 @@ locals {
     }
   } : {}
 
-  access_entries = merge(local.default_access_entries, local.provision_access_entry, local.deprovision_access_entry, local.break_glass_access_entry, var.additional_access_entry)
+  access_entries = merge(local.provision_access_entries, local.deprovision_access_entries, local.maintenance_access_entries, local.break_glass_access_entry, var.additional_access_entry)
 }
 
 resource "aws_kms_key" "eks" {

--- a/module/main.tf
+++ b/module/main.tf
@@ -6,6 +6,10 @@ module "nuon-aws-eks-sandbox" {
   maintenance_iam_role_arn = var.maintenance_iam_role_arn
   deprovision_iam_role_arn = var.deprovision_iam_role_arn
 
+  additional_provision_iam_role_arns   = var.additional_provision_iam_role_arns
+  additional_deprovision_iam_role_arns = var.additional_deprovision_iam_role_arns
+  additional_maintenance_iam_role_arns = var.additional_maintenance_iam_role_arns
+
   provision_role_eks_access_entry_policy_associations   = var.provision_role_eks_access_entry_policy_associations
   maintenance_role_eks_access_entry_policy_associations = var.maintenance_role_eks_access_entry_policy_associations
   deprovision_role_eks_access_entry_policy_associations = var.deprovision_role_eks_access_entry_policy_associations

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -22,6 +22,24 @@ variable "deprovision_iam_role_arn" {
   description = "The deprovision IAM Role ARN"
 }
 
+variable "additional_provision_iam_role_arns" {
+  type        = list(string)
+  description = "Additional provision IAM Role ARNs. Each gets the same EKS access entry config as the primary provision role."
+  default     = []
+}
+
+variable "additional_deprovision_iam_role_arns" {
+  type        = list(string)
+  description = "Additional deprovision IAM Role ARNs. Each gets the same EKS access entry config as the primary deprovision role."
+  default     = []
+}
+
+variable "additional_maintenance_iam_role_arns" {
+  type        = list(string)
+  description = "Additional maintenance IAM Role ARNs. Each gets the same EKS access entry config as the primary maintenance role."
+  default     = []
+}
+
 #
 # from configs
 #

--- a/variables.tf
+++ b/variables.tf
@@ -24,6 +24,18 @@ locals {
     maintenance_iam_role_name = split("/", var.maintenance_iam_role_arn)[length(split("/", var.maintenance_iam_role_arn)) - 1]
     break_glass_iam_role_name = var.break_glass_iam_role_arn != "" ? split("/", var.break_glass_iam_role_arn)[length(split("/", var.break_glass_iam_role_arn)) - 1] : ""
   }
+
+  # Aggregate all role ARNs per type (primary + additional)
+  all_provision_arns   = compact(concat([var.provision_iam_role_arn], var.additional_provision_iam_role_arns))
+  all_deprovision_arns = compact(concat([var.deprovision_iam_role_arn], var.additional_deprovision_iam_role_arns))
+  all_maintenance_arns = concat([var.maintenance_iam_role_arn], var.additional_maintenance_iam_role_arns)
+
+  # Map of role_key => role_name for ECR policy attachments
+  all_role_names = merge(
+    { for i, arn in local.all_provision_arns : "provision-${i}" => split("/", arn)[length(split("/", arn)) - 1] },
+    { for i, arn in local.all_deprovision_arns : "deprovision-${i}" => split("/", arn)[length(split("/", arn)) - 1] },
+    { for i, arn in local.all_maintenance_arns : "maintenance-${i}" => split("/", arn)[length(split("/", arn)) - 1] },
+  )
 }
 
 #
@@ -56,6 +68,24 @@ variable "break_glass_iam_role_arn" {
   type        = string
   description = "The break glass IAM Role ARN. If provided, an EKS access entry will be created for this role."
   default     = ""
+}
+
+variable "additional_provision_iam_role_arns" {
+  type        = list(string)
+  description = "Additional provision IAM Role ARNs. Each gets the same EKS access entry config as the primary provision role."
+  default     = []
+}
+
+variable "additional_deprovision_iam_role_arns" {
+  type        = list(string)
+  description = "Additional deprovision IAM Role ARNs. Each gets the same EKS access entry config as the primary deprovision role."
+  default     = []
+}
+
+variable "additional_maintenance_iam_role_arns" {
+  type        = list(string)
+  description = "Additional maintenance IAM Role ARNs. Each gets the same EKS access entry config as the primary maintenance role."
+  default     = []
 }
 
 #


### PR DESCRIPTION
Allow additional IAM roles for provision, maintenance, and deprovision. This is required to allow giving more than one custom role per operation access to the cluster.