### PR TITLE
chore: make it easier to override or disable addons

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -47,31 +47,8 @@ locals {
   } : {}
 
   access_entries = merge(local.default_access_entries, local.provision_access_entry, local.deprovision_access_entry, local.break_glass_access_entry, var.additional_access_entry)
-}
 
-resource "aws_kms_key" "eks" {
-  description = "Key for ${local.cluster_name} EKS cluster"
-}
-
-module "eks" {
-  source  = "terraform-aws-modules/eks/aws"
-  version = "20.35.0"
-
-  cluster_name                    = local.cluster_name
-  cluster_version                 = local.cluster_version
-  cluster_endpoint_private_access = true
-  cluster_endpoint_public_access  = var.cluster_endpoint_public_access
-
-  vpc_id     = data.aws_vpc.vpc.id
-  subnet_ids = local.subnets.private.ids
-
-  create_kms_key = false
-  cluster_encryption_config = {
-    provider_key_arn = aws_kms_key.eks.arn
-    resources        = ["secrets"]
-  }
-
-  cluster_addons = {
+  default_cluster_addons = {
     coredns = {
       configuration_values = jsonencode({
         tolerations = [
@@ -98,6 +75,37 @@ module "eks" {
       preserve    = true
     }
   }
+
+  # null entries in var.cluster_addons remove a default; everything else overrides/extends
+  cluster_addons = {
+    for k, v in merge(local.default_cluster_addons, var.cluster_addons) :
+    k => v if v != null
+  }
+}
+
+resource "aws_kms_key" "eks" {
+  description = "Key for ${local.cluster_name} EKS cluster"
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.35.0"
+
+  cluster_name                    = local.cluster_name
+  cluster_version                 = local.cluster_version
+  cluster_endpoint_private_access = true
+  cluster_endpoint_public_access  = var.cluster_endpoint_public_access
+
+  vpc_id     = data.aws_vpc.vpc.id
+  subnet_ids = local.subnets.private.ids
+
+  create_kms_key = false
+  cluster_encryption_config = {
+    provider_key_arn = aws_kms_key.eks.arn
+    resources        = ["secrets"]
+  }
+
+  cluster_addons = local.cluster_addons
 
   authentication_mode                      = "API_AND_CONFIG_MAP"
   access_entries                           = local.access_entries

--- a/eks.tf
+++ b/eks.tf
@@ -50,23 +50,22 @@ locals {
 
   default_cluster_addons = {
     coredns = {
-      configuration_values = jsonencode({
+      configuration_values = {
         tolerations = [
           # Allow CoreDNS to run on the same nodes as the Karpenter controller
           # for use during cluster creation when Karpenter nodes do not yet exist
-          #
           {
             key    = "karpenter.sh/controller"
             value  = "true"
             effect = "NoSchedule"
           },
           {
-            key : "CriticalAddonsOnly"
-            value : "true"
-            effect : "NoSchedule"
+            key    = "CriticalAddonsOnly"
+            value  = "true"
+            effect = "NoSchedule"
           },
         ]
-      })
+      }
     }
     eks-pod-identity-agent = {}
     kube-proxy             = {}
@@ -76,10 +75,14 @@ locals {
     }
   }
 
-  # null entries in var.cluster_addons remove a default; everything else overrides/extends
+  # null entries in var.cluster_addons remove a default; everything else overrides/extends.
+  # configuration_values may be passed as an object — we jsonencode it here since the AWS
+  # provider requires a string.
   cluster_addons = {
     for k, v in merge(local.default_cluster_addons, var.cluster_addons) :
-    k => v if v != null
+    k => merge(v, lookup(v, "configuration_values", null) == null ? {} : {
+      configuration_values = try(tostring(v.configuration_values), jsonencode(v.configuration_values))
+    }) if v != null
   }
 }
 

--- a/module/main.tf
+++ b/module/main.tf
@@ -24,6 +24,7 @@ module "nuon-aws-eks-sandbox" {
   max_size              = var.max_size
   desired_size          = var.desired_size
   default_instance_type = var.default_instance_type
+  cluster_addons        = var.cluster_addons
 
   # toggleable components
   enable_nuon_dns = var.enable_nuon_dns

--- a/module/variables.tf
+++ b/module/variables.tf
@@ -14,12 +14,14 @@ variable "maintenance_iam_role_arn" {
 
 variable "provision_iam_role_arn" {
   type        = string
-  description = "The maintenance IAM Role ARN"
+  description = "The provision IAM Role ARN. If empty, no EKS access entry will be created for this role."
+  default     = ""
 }
 
 variable "deprovision_iam_role_arn" {
   type        = string
-  description = "The deprovision IAM Role ARN"
+  description = "The deprovision IAM Role ARN. If empty, no EKS access entry will be created for this role."
+  default     = ""
 }
 
 #
@@ -175,6 +177,12 @@ variable "default_instance_type" {
   type        = string
   default     = "t3a.medium"
   description = "The EC2 instance type to use for the EKS cluster's default node group."
+}
+
+variable "cluster_addons" {
+  type        = any
+  description = "EKS cluster addons to merge on top of the built-in defaults (coredns, eks-pod-identity-agent, kube-proxy, vpc-cni). Provide a map keyed by addon name to override or extend defaults. Set a key to `null` to remove a default addon."
+  default     = {}
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -249,6 +249,12 @@ variable "cluster_endpoint_public_access" {
   default     = false
 }
 
+variable "cluster_addons" {
+  type        = any
+  description = "EKS cluster addons to merge on top of the built-in defaults (coredns, eks-pod-identity-agent, kube-proxy, vpc-cni). Provide a map keyed by addon name to override or extend defaults. Set a key to `null` to remove a default addon."
+  default     = {}
+}
+
 variable "min_size" {
   type        = number
   default     = 2


### PR DESCRIPTION
we have a default set of addons but they have not been configurable. we
have two goals with this change:
1. allow users to disable addons that we ship by default.
2. allow users to configure any addons.
3. preserve backwards compatability in scenarios where users are on main
