### PR TITLE
add karpenter_extra_helm_values variable

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -91,8 +91,8 @@ resource "helm_release" "karpenter" {
   version    = local.karpenter.version
 
   # https://github.com/aws/karpenter-provider-aws/blob/v1.2.2/charts/karpenter/values.yaml
-  values = [
-    yamlencode({
+  values = concat(
+    [yamlencode({
       replicas : var.karpenter_replica_count
       logLevel : "debug"
       settings : {
@@ -131,8 +131,9 @@ resource "helm_release" "karpenter" {
           effect : "NoSchedule"
         },
       ]
-    }),
-  ]
+    })],
+    var.karpenter_extra_helm_values != null ? [yamlencode(var.karpenter_extra_helm_values)] : []
+  )
 
   lifecycle {
     ignore_changes = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -121,6 +121,8 @@ output "karpenter" {
     discovery_key   = local.karpenter.discovery_key
     discovery_value = local.karpenter.discovery_value
 
+    version           = local.karpenter.version
+    extra_helm_values = var.karpenter_extra_helm_values
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -322,6 +322,12 @@ variable "karpenter_ec2nodeclass_default_metadata_options" {
   }
 }
 
+variable "karpenter_extra_helm_values" {
+  type        = map(any)
+  description = "Extra values to pass to the karpenter helm chart."
+  default     = null
+}
+
 variable "additional_tags" {
   type        = map(any)
   description = "Extra tags to append to the default tags that will be added to install resources."


### PR DESCRIPTION
we have a need to enable the `nodeOverlay` karpenter feature gate, and this seems like the cleanest and most generic way to do that from the app side